### PR TITLE
Simplify Method Names

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -19,19 +19,19 @@ h2. Usage
 Heritage works by assigning one model as your @predecessor@, and one or more other models as it's @heir@.
 The predecessor is the parent of it's heirs, and thereby implicitly gives it's heirs access to it's columns, and optionally exposing methods to them.
 
-To mark a model as predecessor, simply use the @acts_as_predecessor@ class-method:
+To mark a model as predecessor, simply use the @parent_model@ class-method:
 
 <pre>
   class Post < ActiveRecord::Base
-    acts_as_predecessor
+    parent_model
   end
 </pre>
 
-To mark a model as heir, simply use the @acts_as_heir_of@ class-method, passing a symbol to the model that is to be the heirs predecessor.
+To mark a model as heir, simply use the @child_of_of@ class-method, passing a symbol to the model that is to be the heirs predecessor.
 
 <pre>
   class BlogPost < ActiveRecord::Base
-    acts_as_heir_of :post
+    child_of_of :post
   end
 </pre>
 
@@ -100,12 +100,12 @@ We can also update attributes like normal through @update_attributes@
 
 h2. Methods
 
-If we want to expose some methods from our predecessor model to it's heirs, we can do so when calling the @acts_as_predecessor@ class-method
+If we want to expose some methods from our predecessor model to it's heirs, we can do so when calling the @parent_model@ class-method
 
 <pre>
   class Post < ActiveRecord::Base
 
-    acts_as_predecessor :exposes => :hello
+    parent_model :exposes => :hello
 
     def hello
       "Hi there!"
@@ -126,7 +126,7 @@ If you for some reason need to override the method in one of your heir-models, y
 <pre>
   class BlogPost < ActiveRecord::Base
 
-    acts_as_heir_of :post
+    child_of_of :post
 
     def hello
       "Yo!"
@@ -147,7 +147,7 @@ If we need to combine the local method in the heir, with the method in the prede
 <pre>
   class BlogPost < ActiveRecord::Base
 
-    acts_as_heir_of :post
+    child_of_of :post
 
     def hello
       "Yo! #{predecessor.hello}"

--- a/README.textile
+++ b/README.textile
@@ -27,11 +27,11 @@ To mark a model as predecessor, simply use the @parent_model@ class-method:
   end
 </pre>
 
-To mark a model as heir, simply use the @child_of_of@ class-method, passing a symbol to the model that is to be the heirs predecessor.
+To mark a model as heir, simply use the @child_of@ class-method, passing a symbol to the model that is to be the heirs predecessor.
 
 <pre>
   class BlogPost < ActiveRecord::Base
-    child_of_of :post
+    child_of :post
   end
 </pre>
 
@@ -126,7 +126,7 @@ If you for some reason need to override the method in one of your heir-models, y
 <pre>
   class BlogPost < ActiveRecord::Base
 
-    child_of_of :post
+    child_of :post
 
     def hello
       "Yo!"
@@ -147,7 +147,7 @@ If we need to combine the local method in the heir, with the method in the prede
 <pre>
   class BlogPost < ActiveRecord::Base
 
-    child_of_of :post
+    child_of :post
 
     def hello
       "Yo! #{predecessor.hello}"

--- a/heritage_demo/Gemfile
+++ b/heritage_demo/Gemfile
@@ -6,7 +6,7 @@ gem 'rails', '3.0.6'
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
 gem 'sqlite3'
-gem "heritage", :path => "~/Projects/benjamin/heritage"
+gem "heritage", :path => "../"
 
 # Use unicorn as the web server
 # gem 'unicorn'

--- a/heritage_demo/Gemfile.lock
+++ b/heritage_demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
-  remote: ~/Projects/benjamin/heritage
+  remote: ../
   specs:
-    heritage (0.3.0)
+    heritage (0.3.1)
 
 GEM
   remote: http://rubygems.org/

--- a/heritage_demo/app/models/blog_post.rb
+++ b/heritage_demo/app/models/blog_post.rb
@@ -1,6 +1,6 @@
 class BlogPost < ActiveRecord::Base
   
-  acts_as_heir_of :post
+  child_of :post
   
   validates_presence_of :body
   validates_presence_of :title

--- a/heritage_demo/app/models/image_post.rb
+++ b/heritage_demo/app/models/image_post.rb
@@ -1,5 +1,5 @@
 class ImagePost < ActiveRecord::Base
   
-  acts_as_heir_of :post
+  child_of :post
   
 end

--- a/heritage_demo/app/models/post.rb
+++ b/heritage_demo/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ActiveRecord::Base
   
-  acts_as_predecessor :exposes => :hello
+  parent_model :exposes => :hello
   
   belongs_to :category
   

--- a/heritage_demo/db/schema.rb
+++ b/heritage_demo/db/schema.rb
@@ -12,20 +12,6 @@
 
 ActiveRecord::Schema.define(:version => 20110412094758) do
 
-  create_table "_blog_posts_old_20110411", :force => true do |t|
-    t.integer  "predecessor_id"
-    t.text     "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "_image_posts_old_20110411", :force => true do |t|
-    t.integer  "predecessor_id"
-    t.integer  "aspect"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "blog_posts", :force => true do |t|
     t.text "body"
   end

--- a/lib/heritage/active_record/acts_as_heir.rb
+++ b/lib/heritage/active_record/acts_as_heir.rb
@@ -2,7 +2,7 @@ module Heritage
   module ActiveRecord
     module ActsAsHeir
 
-      def acts_as_heir_of(predecessor_symbol)
+      def child_of(predecessor_symbol)
         extend ClassMethods
         include InstanceMethods
 

--- a/lib/heritage/active_record/acts_as_predecessor.rb
+++ b/lib/heritage/active_record/acts_as_predecessor.rb
@@ -2,7 +2,7 @@ module Heritage
   module ActiveRecord
     module ActsAsPredecessor
 
-      def acts_as_predecessor(options = {})
+      def parent_model(options = {})
         extend ClassMethods
         include InstanceMethods
 


### PR DESCRIPTION
I changed the phrasing of acts_as_predecessor as acts_as_heir to parent_model and child_of respectively. I think these names are more clear and simple.

``` ruby
# models/media.rb
class Media < ActiveRecord::Base
  parent_model

end

class Book < Media
  child_of :media

end

class Show < Media
  child_of :media

end

```

I also changed the Heritage path in the sample application relative to how it's cloned from git. This will allow the sample app to be tested without making configuration changes.
