### PR TITLE
class and include_predecessor_id paramters added

### DIFF
--- a/lib/heritage/active_record/acts_as_heir.rb
+++ b/lib/heritage/active_record/acts_as_heir.rb
@@ -65,7 +65,7 @@ module Heritage
         self._predecessor_klass.get_heritage_exposed_methods.each do |method_symbol|
           define_method(method_symbol.to_s) do |*args|
             if args.length > 0
-              predecessor.send(method_symbol.to_s, args)
+              predecessor.send(method_symbol.to_s, args.flatten)
             else
               predecessor.send(method_symbol.to_s)
             end

--- a/lib/heritage/active_record/acts_as_heir.rb
+++ b/lib/heritage/active_record/acts_as_heir.rb
@@ -23,15 +23,21 @@ module Heritage
         alias_method_chain :predecessor, :build
 
         # Expose columns from the predecessor
-        self._predecessor_klass.columns.reject{|c| (c.primary and not c.name.eql?("id")) or c.name =~ /^heir_/}.each do |att|
+        self._predecessor_klass.columns.reject{|c| c.primary and not c.name.eql?("id") }.each do |att|
           if att.primary then
-            if ( not defined? params[:include_predecessor_id] or params[:include_predecessor_id].nil? or params[:include_predecessor_id] == false) then
-              next
-            else
+            if ( defined? params[:include_predecessor_id] and not params[:include_predecessor_id].nil? and params[:include_predecessor_id] == true) then
               define_method(predecessor_symbol.to_s.underscore + "_id") do
                 predecessor.send(att.name)
               end
             end
+            next
+          end
+
+          if att.name =~ /^heir_/ then
+            define_method(predecessor_symbol.to_s.underscore + att.name) do
+              predecessor.send(att.name)
+            end
+            next
           end
 
           define_method(att.name) do


### PR DESCRIPTION
Hi!

I've added a :class => "::Namespace::ClassName" parameter to acts_as_heir_of to be able to inherit classes from other namespace. This also fixes a bug when the predecessor class name was camelized (like: ActivityItem).

And I've added a :include_predecessor_id => true parameter what adds {predecessor_name}_id as an attribute to the child class.

Regards, David
