### PR TITLE
Predecessor does not *always* have an Heir

### DIFF
--- a/heritage_demo/.gitignore
+++ b/heritage_demo/.gitignore
@@ -2,3 +2,5 @@
 db/*.sqlite3
 log/*.log
 tmp/
+.idea
+

--- a/heritage_demo/Gemfile
+++ b/heritage_demo/Gemfile
@@ -12,6 +12,7 @@ group :test do
 	gem 'rspec-rails'
 	gem 'factory_girl_rails'
 	gem 'autotest'
-	gem 'autotest-fsevent'
-	gem 'autotest-growl'
+# MacOSX only
+#	gem 'autotest-fsevent'
+#	gem 'autotest-growl'
 end

--- a/heritage_demo/Gemfile.lock
+++ b/heritage_demo/Gemfile.lock
@@ -37,9 +37,6 @@ GEM
     arel (2.0.9)
     autotest (4.4.6)
       ZenTest (>= 4.4.1)
-    autotest-fsevent (0.2.7)
-      sys-uname
-    autotest-growl (0.2.16)
     builder (2.1.2)
     diff-lcs (1.1.3)
     erubis (2.6.6)
@@ -90,7 +87,6 @@ GEM
       railties (~> 3.0)
       rspec (~> 2.7.0)
     sqlite3 (1.3.3)
-    sys-uname (0.8.6)
     thor (0.14.6)
     treetop (1.4.9)
       polyglot (>= 0.3.1)
@@ -101,8 +97,6 @@ PLATFORMS
 
 DEPENDENCIES
   autotest
-  autotest-fsevent
-  autotest-growl
   factory_girl_rails
   heritage!
   rails (= 3.0.6)

--- a/heritage_demo/db/schema.rb
+++ b/heritage_demo/db/schema.rb
@@ -12,20 +12,6 @@
 
 ActiveRecord::Schema.define(:version => 20110412094758) do
 
-  create_table "_blog_posts_old_20110411", :force => true do |t|
-    t.integer  "predecessor_id"
-    t.text     "body"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
-  create_table "_image_posts_old_20110411", :force => true do |t|
-    t.integer  "predecessor_id"
-    t.integer  "aspect"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "blog_posts", :force => true do |t|
     t.text "body"
   end

--- a/lib/heritage/active_record/acts_as_heir.rb
+++ b/lib/heritage/active_record/acts_as_heir.rb
@@ -23,7 +23,7 @@ module Heritage
         alias_method_chain :predecessor, :build
 
         # Expose columns from the predecessor
-        self._predecessor_klass.columns.reject{|c| c.primary and not c.name.eql?("id") }.each do |att|
+        self._predecessor_klass.columns.reject{|c| c.primary and not ["id", "created_at", "updated_at"].include?(c.name) }.each do |att|
           if att.primary then
             if ( defined? params[:include_predecessor_id] and not params[:include_predecessor_id].nil? and params[:include_predecessor_id] == true) then
               define_method(predecessor_symbol.to_s.underscore + "_id") do

--- a/lib/heritage/active_record/acts_as_heir.rb
+++ b/lib/heritage/active_record/acts_as_heir.rb
@@ -2,11 +2,11 @@ module Heritage
   module ActiveRecord
     module ActsAsHeir
       
-      def child_of(parent_symbol, params)
+      def child_of(parent_symbol, params = nil)
         acts_as_heir_of(parent_symbol, params)
       end
 
-      def acts_as_heir_of(predecessor_symbol, params)
+      def acts_as_heir_of(predecessor_symbol, params = nil)
         extend ClassMethods
         include InstanceMethods
 
@@ -15,7 +15,7 @@ module Heritage
         if defined? params and not params.nil? and defined? params[:class] and not params[:class].nil? then
           self._predecessor_klass = params[:class].constantize
         else
-          self._predecessor_klass = predecessor_symbol.constantize
+          self._predecessor_klass = predecessor_symbol.to_s.camelcase.constantize
         end
 
         has_one :predecessor, :as => :heir, :class_name => self._predecessor_klass.to_s, :autosave => true, :dependent => :destroy

--- a/lib/heritage/active_record/acts_as_heir.rb
+++ b/lib/heritage/active_record/acts_as_heir.rb
@@ -23,15 +23,21 @@ module Heritage
         alias_method_chain :predecessor, :build
 
         # Expose columns from the predecessor
-        self._predecessor_klass.columns.reject{|c| (c.primary and not c.name.eql?("id")) or c.name =~ /^heir_/}.each do |att|
+        self._predecessor_klass.columns.reject{|c| c.primary and not c.name.eql?("id") }.each do |att|
           if att.primary then
-            if ( not defined? params[:include_predecessor_id] or params[:include_predecessor_id].nil? or params[:include_predecessor_id] == false) then
-              next
-            else
+            if ( defined? params[:include_predecessor_id] and not params[:include_predecessor_id].nil? and params[:include_predecessor_id] == true) then
               define_method(predecessor_symbol.to_s.underscore + "_id") do
                 predecessor.send(att.name)
               end
             end
+            next
+          end
+
+          if att.name =~ /^heir_/ then
+            define_method(predecessor_symbol.to_s.underscore + att.name) do
+              predecessor.send(att.name)
+            end
+            next
           end
 
           define_method(att.name) do

--- a/lib/heritage/active_record/acts_as_predecessor.rb
+++ b/lib/heritage/active_record/acts_as_predecessor.rb
@@ -16,7 +16,7 @@ module Heritage
 
         belongs_to :heir, :polymorphic => true
 
-        before_update :touch_heir, :unless => lambda { heir.changed? }
+        before_update :touch_heir, :unless => lambda { heir && heir.changed? }
       end
 
       module ClassMethods
@@ -30,7 +30,7 @@ module Heritage
 
       module InstanceMethods
         def touch_heir
-          if self.changed?
+          if self.changed? && heir
             heir.touch
           end
         end

--- a/lib/heritage/version.rb
+++ b/lib/heritage/version.rb
@@ -1,3 +1,3 @@
 module Heritage
-  VERSION = "0.3.1"
+  VERSION = "0.3.1.2"
 end


### PR DESCRIPTION
I made some changes based on the requirements of a current project:
1) That the acts_as_heir_of may be passed a symbol that needs to be converted to camel case (e.g. FeedbackNode), so I used the fork from 'davidkovaccs' which had already included a fix for this
2) I did a small fix on signatures for David's change
3) The acts_as_predecessor now does not _always_ assume that there is an heir.
