### PR TITLE
Bugfix, looking for incorrect model name key has underscore

### DIFF
--- a/lib/heritage/active_record/acts_as_heir.rb
+++ b/lib/heritage/active_record/acts_as_heir.rb
@@ -14,7 +14,7 @@ module Heritage
         self._predecessor_symbol = predecessor_symbol
         self._predecessor_klass = Object.const_get(predecessor_symbol.to_s.capitalize)
 
-        has_one :predecessor, :as => :heir, :class_name => predecessor_symbol.to_s.capitalize, :autosave => true, :dependent => :destroy
+        has_one :predecessor, :as => :heir, :class_name => predecessor_symbol.to_s.camelize, :autosave => true, :dependent => :destroy
 
         alias_method_chain :predecessor, :build
 


### PR DESCRIPTION
Error:
Expected /path_to_app/app/models/content_block.rb to define Content_block

Should be ContentBlock

Commit Message:
Was using capitalize to get model name from key. Should be using Camelize
